### PR TITLE
Cambiar puerto de Nginx

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,10 +56,10 @@ RUN chown -R nobody.nobody /srv/www/html /run /var/lib/nginx /var/log/nginx /tmp
 USER nobody
 
 # Expose the port nginx is reachable on
-EXPOSE 8080
+EXPOSE 7080
 
 # Let supervisord start nginx & php-fpm
 CMD ["/usr/bin/supervisord", "-c", "/etc/supervisor/conf.d/supervisord.conf"]
 
 # Configure a healthcheck to validate that everything is up&running
-HEALTHCHECK --timeout=10s CMD curl --silent --fail http://127.0.0.1:8080/fpm-ping
+HEALTHCHECK --timeout=10s CMD curl --silent --fail http://127.0.0.1:7080/fpm-ping

--- a/config/nginx-clubcelica.conf
+++ b/config/nginx-clubcelica.conf
@@ -1,7 +1,7 @@
 # Club Celica España server definition
 server {
-	listen [::]:8080;
-	listen 8080;
+	listen [::]:7080;
+	listen 7080;
 	server_name foro.clubcelica.es;
 
 	# Sets the maximum allowed size of the client request body

--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -30,8 +30,8 @@ http {
 
   # Default server definition
   server {
-    listen [::]:8080 default_server;
-    listen 8080 default_server;
+    listen [::]:7080 default_server;
+    listen 7080 default_server;
     server_name _;
 
     sendfile off;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - lan
       - wan
     ports:
-      - "8080:8080"
+      - "7080:7080"
     volumes:
       # Sets the timezone of the host to the container
       - /etc/localtime:/etc/localtime:ro
@@ -42,7 +42,7 @@ services:
       traefik.http.routers.nginx-php.entrypoints: "websecure"
       traefik.http.routers.nginx-php.service: "nginx-php"
       # Ports to expose
-      traefik.http.services.nginx-php.loadbalancer.server.port: "8080"
+      traefik.http.services.nginx-php.loadbalancer.server.port: "7080"
 
   backup:
     build:

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env sh
 apk --no-cache add curl
-curl --silent --fail http://nginx-php:8080 | grep 'PHP 7.4'
+curl --silent --fail http://nginx-php:7080 | grep 'PHP 7.4'


### PR DESCRIPTION
El puerto ha sido sustituido para dejárselo libre al agente de CrowdSec que será desplegado en breve.

Closes #8 