### PR TITLE
Eliminar prefijo de las trazas de PHP

### DIFF
--- a/config/fpm-pool.conf
+++ b/config/fpm-pool.conf
@@ -2,6 +2,9 @@
 ; Log to file
 error_log = /var/log/php-fpm/error.log
 
+; this prevents a bigger json to be splitted into multiple lines
+log_limit = 8192
+
 [www]
 ; The address on which to accept FastCGI requests.
 ; Valid syntaxes are:
@@ -51,3 +54,6 @@ catch_workers_output = yes
 
 ; Enable ping page to use in healthcheck
 ping.path = /fpm-ping
+
+; this will void the warning messages on the log output
+decorate_workers_output = no

--- a/config/php.ini
+++ b/config/php.ini
@@ -14,3 +14,6 @@ upload_max_filesize=25M
 ; secure cookies
 session.cookie_secure=1
 session.cookie_httponly=1
+
+; length of a single log message
+log_errors_max_len = 8192


### PR DESCRIPTION
Eliminado el prefijo que dificulta la lectura de las trazas.